### PR TITLE
Support Git::Hooks version 2.0

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,7 @@
 requires 'perl', '5.10.1';
 
 requires 'Jenkins::API';
-requires 'Git::Hooks';
+requires 'Git::Hooks', '>= 2.0';
 
 requires 'Git::Mailmap';
 

--- a/lib/Git/MoreHooks/CheckCommitAuthorFromMailmap.pm
+++ b/lib/Git/MoreHooks/CheckCommitAuthorFromMailmap.pm
@@ -238,7 +238,7 @@ sub check_commit_at_client {
     my ($git) = @_;
 
     my $current_branch = $git->get_current_branch();
-    return 1 unless is_ref_enabled( $current_branch, $git->get_config( $CFG => 'ref' ) );
+    return 1 unless $git->is_ref_enabled( $current_branch, $git->get_config( $CFG => 'ref' ) );
 
     my $author_name  = $ENV{'GIT_AUTHOR_NAME'};
     my $author_email = '<' . $ENV{'GIT_AUTHOR_EMAIL'} . '>';
@@ -340,7 +340,7 @@ sub _check_mailmap {
 sub check_ref {
     my ( $git, $ref ) = @_;
 
-    return 1 unless is_ref_enabled( $ref, $git->get_config( $CFG => 'ref' ) );
+    return 1 unless $git->is_ref_enabled( $ref, $git->get_config( $CFG => 'ref' ) );
 
     my $errors = 0;
     foreach my $commit ( $git->get_affected_ref_commits($ref) ) {
@@ -380,7 +380,7 @@ sub check_patchset {
     my $branch = $opts->{'--branch'};
     $branch = "refs/heads/$branch"
       unless $branch =~ m:^refs/:;
-    return 1 unless is_ref_enabled( $branch, $git->get_config( $CFG => 'ref' ) );
+    return 1 unless $git->is_ref_enabled( $branch, $git->get_config( $CFG => 'ref' ) );
 
     return check_commit_at_server( $git, $commit );
 }

--- a/lib/Git/MoreHooks/CheckCommitAuthorFromMailmap.pm
+++ b/lib/Git/MoreHooks/CheckCommitAuthorFromMailmap.pm
@@ -201,7 +201,7 @@ L<Git::Hooks|https://metacpan.org/pod/Git::Hooks> package.
 
 =cut
 
-use Git::Hooks qw{:DEFAULT :utils};
+use Git::Hooks;
 use Path::Tiny;
 use Log::Any qw{$log};
 require Git::Mailmap;
@@ -260,7 +260,7 @@ sub _check_author {
 
     _setup_config($git);
 
-    return 1 if im_admin($git);
+    return 1 if $git->im_admin();
 
     my $errors = 0;
     _check_mailmap( $git, $author_name, $author_email ) or ++$errors;
@@ -274,7 +274,7 @@ sub _check_mailmap {
     my $errors            = 0;
     my $author            = $author_name . q{ } . $author_email;
     my $mailmap           = Git::Mailmap->new();
-    my $mailmap_as_string = $git->command( 'show', 'HEAD:.mailmap' );
+    my $mailmap_as_string = $git->run( 'show', 'HEAD:.mailmap' );
     if ( defined $mailmap_as_string ) {
         $mailmap->from_string( 'mailmap' => $mailmap_as_string );
         $log->debugf( '_check_mailmap(): HEAD:.mailmap read in.' . ' Content from Git::Mailmap:\n%s', $mailmap->to_string() );

--- a/lib/Git/MoreHooks/CheckCommitBase.pm
+++ b/lib/Git/MoreHooks/CheckCommitBase.pm
@@ -133,7 +133,7 @@ L<Git::Hooks|https://metacpan.org/pod/Git::Hooks> package.
 
 =cut
 
-use Git::Hooks qw{:DEFAULT :utils};
+use Git::Hooks;
 use Path::Tiny;
 use Log::Any qw{$log};
 use Params::Validate qw(:all);

--- a/lib/Git/MoreHooks/CheckIndent.pm
+++ b/lib/Git/MoreHooks/CheckIndent.pm
@@ -149,7 +149,7 @@ L<Git::Hooks|https://metacpan.org/pod/Git::Hooks> package.
 
 use Git::MoreHooks::CheckCommitBase \&do_hook;
 
-use Git::Hooks qw{:DEFAULT :utils};
+use Git::Hooks;
 use Path::Tiny;
 use Log::Any qw{$log};
 use Params::Validate qw(:all);
@@ -279,7 +279,7 @@ sub do_hook {
     my ($git, $hook_name, $opts) = @_;
     $log->tracef( 'do_hook(%s)', (join q{:}, @_) );
 
-    return 1 if im_admin($git);
+    return 1 if $git->im_admin();
     if ( !_setup_config($git) ) {
         return 0;
     }

--- a/lib/Git/MoreHooks/TriggerJenkins.pm
+++ b/lib/Git/MoreHooks/TriggerJenkins.pm
@@ -506,7 +506,7 @@ sub handle_affected_refs {
     }
 
     foreach my $ref ( $git->get_affected_refs() ) {
-        if ( !is_ref_enabled( $ref, $git->get_config( $CFG => 'ref' ) ) ) {
+        if ( ! $git->is_ref_enabled( $ref, $git->get_config( $CFG => 'ref' ) ) ) {
             if ( $git->get_config( $CFG => 'quiet' ) eq '0' ) {
                 print "Ref '$ref' not enabled.\n";
             }
@@ -555,7 +555,7 @@ sub handle_commit_at_client {
     my ($git) = @_;
 
     my $current_branch = $git->get_current_branch();
-    if ( !is_ref_enabled( $current_branch, $git->get_config( $CFG => 'ref' ) ) ) {
+    if ( ! $git->is_ref_enabled( $current_branch, $git->get_config( $CFG => 'ref' ) ) ) {
         if ( $git->get_config( $CFG => 'quiet' ) eq '0' ) {
             print "Ref '$current_branch' not enabled.\n";
         }

--- a/lib/Git/MoreHooks/TriggerJenkins.pm
+++ b/lib/Git/MoreHooks/TriggerJenkins.pm
@@ -222,7 +222,7 @@ Cxense Sweden AB's permission.
 
 =cut
 
-use Git::Hooks qw{:DEFAULT :utils};
+use Git::Hooks;
 use Path::Tiny;
 use Log::Any qw{$log};
 use Carp;
@@ -514,15 +514,16 @@ sub handle_affected_refs {
         }
 
         my $new_commit = ( $git->get_affected_ref_range($ref) )[1];
-        if ( $new_commit =~ m/^[0]{1,}$/msx ) {    # Just zeros, deleted branch.
+        if ( $new_commit eq $git->undef_commit() ) {    # Just zeros, deleted branch.
             delete_job( $git, $ref );
         }
         else {
-            my @commit_ids = $git->get_affected_ref_commit_ids($ref);
-            $log->debugf( 'commit_ids (from get_affected_ref_commit_ids(%s):%s', $ref, \@commit_ids );
+            my @commits = $git->get_affected_ref_commits($ref);
+            $log->debugf( 'commit_ids (from get_affected_ref_commit_ids(%s):%s', $ref,
+                          [map {$_->commit()} @commits] );
             my $nr_msg_ok_to_trigger = 0;
-            foreach my $commit_id (@commit_ids) {
-                my $commit_msg = $git->get_commit_msg($commit_id);
+            foreach my $commit (@commits) {
+                my $commit_msg = $commit->message();
                 $log->debugf( 'commit message: \'%s\'.', ( substr $commit_msg, 0, $LAST_CHAR_IN_STRING ) );
                 if ( !$git->get_config( $CFG => 'allow-commit-msg' ) ) {
                     $log->debugf('No option allow-commit-msg. Allow all.');


### PR DESCRIPTION
I just released a TRIAL version 2.0.0 of Git::Hooks which introduces some incompatible changes.

I think your plugin needs just a few small changes to make it compatible with the new version of Git::Hooks.  I haven't tested it though.

I'm not used to carton... so I'm not sure if the change I made in the cpanfile is what needs to be done to make your plugin depend on Git::Hooks 2.0.

I hope it helps!